### PR TITLE
管理画面のヘッダーとサイドバーのMaterial UIへの置き換え

### DIFF
--- a/components/pit/PitDashboard.tsx
+++ b/components/pit/PitDashboard.tsx
@@ -1,25 +1,62 @@
 import {PitHeader} from "./PitHeader";
 import {PitSidebar} from "./PitSidebar";
 import styles from "../../styles/Pit.module.scss";
-import {ReactNode} from "react";
+import {ReactNode, useState} from "react";
 import Head from "next/head";
+import {Box, createTheme, CssBaseline, Paper} from "@mui/material";
+import {ThemeProvider} from "@mui/material/styles";
 
-export function PitDashboard(props: {children: ReactNode}) {
+export function PitDashboard(props: { children: ReactNode }) {
+    const theme = createTheme()
+    //  sidebar
+    const [isSidebarOpen, setSidebarOpen] = useState<boolean>(false)
+
     return (
         <>
             <Head>
                 <title>Pit</title>
                 <meta name="description" content="Pit Dashboard"/>
             </Head>
-            <div className={styles.pit}>
-                <PitHeader/>
-                <div className={styles.dashboard}>
-                    <PitSidebar/>
-                    <div className={styles.container}>
+
+            <ThemeProvider theme={theme}>
+                <CssBaseline/>
+
+                <Box
+                    sx={{
+                        display: "flex",
+                        flexDirection: "column",
+                        height: "100vh",
+                    }}
+                >
+
+                    <PitHeader
+                        openSidebarFunction={() => {
+                            setSidebarOpen(true)
+                        }}
+                    />
+                    <PitSidebar
+                        isOpenSidebar={isSidebarOpen}
+                        closeSidebarFunction={() => {
+                            setSidebarOpen(false)
+                        }}
+                    />
+
+                    <Box
+                        sx={{
+                            flexGrow: 1,
+                            overflow: "auto",
+                            width: "100%",
+                            padding: "10px 20px 40px 20px"
+                        }}
+                    >
                         {props.children}
-                    </div>
-                </div>
-            </div>
+                    </Box>
+
+                </Box>
+
+
+            </ThemeProvider>
         </>
+
     )
 }

--- a/components/pit/PitDashboard.tsx
+++ b/components/pit/PitDashboard.tsx
@@ -1,9 +1,8 @@
 import {PitHeader} from "./PitHeader";
 import {PitSidebar} from "./PitSidebar";
-import styles from "../../styles/Pit.module.scss";
 import {ReactNode, useState} from "react";
 import Head from "next/head";
-import {Box, createTheme, CssBaseline, Paper} from "@mui/material";
+import {Box, createTheme, CssBaseline} from "@mui/material";
 import {ThemeProvider} from "@mui/material/styles";
 
 export function PitDashboard(props: { children: ReactNode }) {

--- a/components/pit/PitHeader.tsx
+++ b/components/pit/PitHeader.tsx
@@ -1,19 +1,45 @@
 import Link from "next/link";
 import Image from "next/image";
 import styles from "../../styles/Pit.module.scss";
+import {AppBar, IconButton, Toolbar, Typography} from "@mui/material";
+import {MenuIcon} from "lucide-react";
 
-export function PitHeader() {
+export type PitHeaderProps = {
+    openSidebarFunction: () => void,
+}
+
+export function PitHeader(props: PitHeaderProps) {
 
     return (
-        <header>
-            <Link href={"/admin"} className={styles.logo}>
-                <Image
-                    src={"/pit.svg"}
-                    alt={"Pit Logo"}
-                    width={91}
-                    height={30}
-                />
-            </Link>
-        </header>
+
+        <AppBar position={"static"}>
+            <Toolbar>
+                <IconButton
+                    size="large"
+                    edge="start"
+                    color="inherit"
+                    aria-label="menu"
+                    sx={{ mr: 2 }}
+                    onClick={() => {
+                        props.openSidebarFunction()
+                    }}
+                >
+                    <MenuIcon />
+                </IconButton>
+
+                <Link
+                    href={"/"}
+                >
+                    <Typography
+                        variant="h6"
+                        component="div"
+                        sx={{ px: 1, py: 1 }}
+                    >
+                        Pit
+                    </Typography>
+                </Link>
+
+            </Toolbar>
+        </AppBar>
     )
 }

--- a/components/pit/PitHeader.tsx
+++ b/components/pit/PitHeader.tsx
@@ -1,6 +1,4 @@
 import Link from "next/link";
-import Image from "next/image";
-import styles from "../../styles/Pit.module.scss";
 import {AppBar, IconButton, Toolbar, Typography} from "@mui/material";
 import {MenuIcon} from "lucide-react";
 
@@ -19,12 +17,12 @@ export function PitHeader(props: PitHeaderProps) {
                     edge="start"
                     color="inherit"
                     aria-label="menu"
-                    sx={{ mr: 2 }}
+                    sx={{mr: 2}}
                     onClick={() => {
                         props.openSidebarFunction()
                     }}
                 >
-                    <MenuIcon />
+                    <MenuIcon/>
                 </IconButton>
 
                 <Link
@@ -33,7 +31,7 @@ export function PitHeader(props: PitHeaderProps) {
                     <Typography
                         variant="h6"
                         component="div"
-                        sx={{ px: 1, py: 1 }}
+                        sx={{px: 1, py: 1}}
                     >
                         Pit
                     </Typography>

--- a/components/pit/PitSidebar.tsx
+++ b/components/pit/PitSidebar.tsx
@@ -1,6 +1,5 @@
 import {Drawer, List, ListItem, ListItemButton, ListItemText} from "@mui/material";
 
-
 export type PitSidebarProps = {
     isOpenSidebar: boolean,
     closeSidebarFunction: () => void,

--- a/components/pit/PitSidebar.tsx
+++ b/components/pit/PitSidebar.tsx
@@ -1,53 +1,77 @@
-import styles from "../../styles/Pit.module.scss";
-import {PitSidebarContent} from "./PitSidebarContent";
+import {Drawer, List, ListItem, ListItemButton, ListItemText} from "@mui/material";
 
-export function PitSidebar() {
+
+export type PitSidebarProps = {
+    isOpenSidebar: boolean,
+    closeSidebarFunction: () => void,
+}
+
+type ContentType = {
+    name: string,
+    url: string,
+}
+
+export function PitSidebar(props: PitSidebarProps) {
+
+    const contents: ContentType[] = [
+        {
+            name: "インフォメーション",
+            url: "/admin/information",
+        },
+        {
+            name: "チーム",
+            url: "/admin/teams",
+        },
+        {
+            name: "ユーザー",
+            url: "/admin/users",
+        },
+        {
+            name: "競技",
+            url: "/admin/sports",
+        },
+        {
+            name: "マッチ",
+            url: "/admin/matches",
+        },
+        {
+            name: "ロケーション",
+            url: "/admin/locations",
+        },
+        {
+            name: "画像",
+            url: "/admin/images",
+        },
+        {
+            name: "タグ",
+            url: "/admin/tags",
+        },
+        {
+            name: "Microsoftアカウント",
+            url: "/admin/microsoft-accounts",
+        },
+    ]
+
     return (
-        <div className={styles.sidebar}>
-            {/*<PitSidebarContent*/}
-            {/*    name={"グループ"}*/}
-            {/*    url={"/admin/groups"}*/}
-            {/*/>*/}
-            {/*<PitSidebarContent*/}
-            {/*    name={"クラス"}*/}
-            {/*    url={"/admin/classes"}*/}
-            {/*/>*/}
-            <PitSidebarContent
-                name={"インフォメーション"}
-                url={"/admin/information"}
-            />
-            <PitSidebarContent
-                name={"チーム"}
-                url={"/admin/teams"}
-            />
-            <PitSidebarContent
-                name={"ユーザー"}
-                url={"/admin/users"}
-            />
-            <PitSidebarContent
-                name={"競技"}
-                url={"/admin/sports"}
-            />
-            <PitSidebarContent
-                name={"マッチ"}
-                url={"/admin/matches"}
-            />
-            <PitSidebarContent
-                name={"ロケーション"}
-                url={"/admin/locations"}
-            />
-            <PitSidebarContent
-                name={"画像"}
-                url={"/admin/images"}
-            />
-            <PitSidebarContent
-                name={"タグ"}
-                url={"/admin/tags"}
-            />
-            <PitSidebarContent
-                name={"Microsoftアカウント"}
-                url={"/admin/microsoft-accounts"}
-            />
-        </div>
+        <Drawer
+            open={props.isOpenSidebar}
+            onClose={() => {
+                props.closeSidebarFunction()
+            }}
+        >
+            <List>
+                {
+                    contents.map((content, index) => {
+                        return (
+                            <ListItem key={index} disablePadding>
+                                <ListItemButton href={content.url}>
+                                    <ListItemText primary={content.name}/>
+                                </ListItemButton>
+                            </ListItem>
+                        )
+                    })
+                }
+            </List>
+        </Drawer>
     )
 }


### PR DESCRIPTION
# チケット

#68 

# 実装内容

- MUI Themeを追加
- MUI App Barを追加
- MUI Sidebar(Drawer)を追加
